### PR TITLE
Remove the fixltex2e usepacakge command.

### DIFF
--- a/inst/templates/APA6.Rnw
+++ b/inst/templates/APA6.Rnw
@@ -13,7 +13,6 @@
 
 \usepackage{graphicx}
 
-\usepackage{fixltx2e}
 \usepackage{subcaption}
 \usepackage{float}
 


### PR DESCRIPTION
All of the bugfixes contained in this package are part of the base LaTeX release.